### PR TITLE
fix: Change from golang.org/x/exp/slog to log/slog

### DIFF
--- a/fxslog.go
+++ b/fxslog.go
@@ -3,8 +3,9 @@ package fxslog
 import (
 	"strings"
 
+	"log/slog"
+
 	"go.uber.org/fx/fxevent"
-	"golang.org/x/exp/slog"
 )
 
 // FxLogger is an Fx event logger that logs events to slog.
@@ -19,11 +20,11 @@ func New(logger *slog.Logger) *FxLogger {
 }
 
 func (l *FxLogger) logError(msg string, fields ...slog.Attr) {
-	l.Logger.LogAttrs(slog.ErrorLevel, msg, fields...)
+	l.Logger.LogAttrs(nil, slog.LevelError, msg, fields...)
 }
 
 func (l *FxLogger) logEvent(msg string, fields ...slog.Attr) {
-	l.Logger.LogAttrs(slog.InfoLevel, msg, fields...)
+	l.Logger.LogAttrs(nil, slog.LevelInfo, msg, fields...)
 }
 
 // LogEvent logs the given event to the provided Zap logger.

--- a/fxslog_test.go
+++ b/fxslog_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"log/slog"
+
 	"github.com/ipfans/fxslog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxevent"
-	"golang.org/x/exp/slog"
 )
 
 func TestFxLogger(t *testing.T) {
@@ -281,14 +282,14 @@ func TestFxLogger(t *testing.T) {
 
 			var buf bytes.Buffer
 			handler := slog.HandlerOptions{
-				ReplaceAttr: func(attr slog.Attr) slog.Attr {
+				ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
 					if attr.Key == slog.TimeKey || attr.Key == slog.LevelKey {
 						return slog.Attr{}
 					}
 					return attr
 				},
-			}.NewJSONHandler(&buf)
-			l := fxslog.New(slog.New(handler))
+			}
+			l := fxslog.New(slog.New(slog.NewJSONHandler(&buf, &handler)))
 
 			l.LogEvent(tt.give)
 
@@ -305,7 +306,7 @@ func TestFxLogger(t *testing.T) {
 func ExampleNew() {
 	app := fx.New(
 		fx.Provide(func() *slog.Logger {
-			return slog.New(slog.NewJSONHandler(os.Stdout))
+			return slog.New(slog.NewJSONHandler(os.Stdout, nil))
 		}),
 		fx.WithLogger(func(logger *slog.Logger) fxevent.Logger {
 			return fxslog.New(logger)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfans/fxslog
 
-go 1.19
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.8.1


### PR DESCRIPTION
Use `log/slog` from the standard library.